### PR TITLE
Fix falsy attribute values being dropped

### DIFF
--- a/lib/serializer-utils.js
+++ b/lib/serializer-utils.js
@@ -233,7 +233,7 @@ module.exports = function (collectionName, record, payload, opts) {
     }
 
     _.each(opts.attributes, function (attribute) {
-      if (record[attribute]) {
+      if (record[attribute] != null) {
         if (!data.attributes) { data.attributes = {}; }
         that.serialize(data, record, attribute, opts[attribute]);
       } else {

--- a/test/serializer.js
+++ b/test/serializer.js
@@ -1662,4 +1662,23 @@ describe('JSON API Serializer', function () {
       expect(json.data.attributes).to.have.property('last-name');
     });
   });
+
+  describe('False attribute values', function () {
+    it('should property output attributes', function () {
+      var dataSet = {
+        id:    '1',
+        count: 0,
+        bool:  false,
+      };
+
+      var json = new JSONAPISerializer('users', {
+        attributes: ['count', 'bool']
+      }).serialize(dataSet);
+
+      expect(json.data.attributes).to.have.property('count');
+      expect(json.data.attributes).to.have.property('bool');
+      expect(json.data.attributes.count).to.equal(0);
+      expect(json.data.attributes.bool).to.equal(false);
+    });
+  });
 });


### PR DESCRIPTION
False values are being ignored in latest version.

```js
new Serializer('test', { foo: false }, { attributes: ['foo'] });

// output
{ 
  data: { 
    id: undefined,
    type: 'test',
    // missing attributes
  }
}
```
Same for any falsy values such as `0`.